### PR TITLE
Add diff_color variant

### DIFF
--- a/search/circles/circles_loaders.tcl
+++ b/search/circles/circles_loaders.tcl
@@ -8,7 +8,7 @@
 
 namespace eval search::circles {
     proc loaders_init { s } {
-	$s add_method basic_search { nr nd targ_r dist_prop mindist targ_range targ_color } {
+        $s add_method basic_search { nr nd targ_r dist_prop mindist targ_range targ_color {dist_color {}} } {
 	    set n_rep $nr
 	    set ndists $nd
 	    
@@ -52,8 +52,10 @@ namespace eval search::circles {
 	    dl_set $g:dist_ys \
 		[dl_unpack [dl_choose $g:dists_pos [dl_llist [dl_llist 1]]]]
 	    
-	    set dist_r [expr $scale*$dist_prop]
-	    set dist_color $targ_color
+            set dist_r [expr $scale*$dist_prop]
+            if { $dist_color == {} } {
+                set dist_color $targ_color
+            }
 	    
 	    dl_set $g:dist_rs [dl_repeat $dist_r [dl_llength $g:dist_xs]]
 	    dl_set $g:dist_colors \

--- a/search/circles/circles_variants.tcl
+++ b/search/circles/circles_variants.tcl
@@ -46,20 +46,38 @@ namespace eval search::circles {
 	    }
 	    params { interblock_time 750 }
 	}
-	distractors {
-	    description "fixed number of distractors"
-	    loader_proc basic_search
-	    loader_options {
-		nr { 100 200 }
-		nd { 4 6 8 }
-		targ_r { 1.5 2.0 }
-		dist_prop { 1.2 1.1 0.9 0.8 }
-		mindist { 2.0 3.0 }
-		targ_range { 8 9 10 }
+        distractors {
+            description "fixed number of distractors"
+            loader_proc basic_search
+            loader_options {
+                nr { 100 200 }
+                nd { 4 6 8 }
+                targ_r { 1.5 2.0 }
+                dist_prop { 1.2 1.1 0.9 0.8 }
+                mindist { 2.0 3.0 }
+                targ_range { 8 9 10 }
                 targ_color {
                     { cyan { 0 1 1 } }
                     { red { 1 0 0 } }
                     { purple { 1 0 1 } }
+                }
+            }
+        }
+        diff_color {
+            description "distractors marked by color"
+            loader_proc basic_search
+            loader_options {
+                nr { 100 }
+                nd { 4 }
+                targ_r { 1 }
+                dist_prop { 1 }
+                mindist { 2.0 }
+                targ_range { 8 9 10 }
+                targ_color {
+                    { blue { 0 0 1 } }
+                }
+                dist_color {
+                    { red { 1 0 0 } }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- extend `basic_search` loader with optional `dist_color` argument
- add `diff_color` variant using color to mark distractors

## Testing
- `tclsh search/circles/circles_loaders.tcl`

------
https://chatgpt.com/codex/tasks/task_e_6855b2d661e0832c974e6e613939db12