### PR TITLE
Add diff_color variant

### DIFF
--- a/search/circles/circles_loaders.tcl
+++ b/search/circles/circles_loaders.tcl
@@ -8,7 +8,7 @@
 
 namespace eval search::circles {
     proc loaders_init { s } {
-	$s add_method basic_search { nr nd targ_r dist_prop mindist targ_range targ_color } {
+        $s add_method basic_search { nr nd targ_r dist_prop mindist targ_range targ_color dist_color } {
 	    set n_rep $nr
 	    set ndists $nd
 	    
@@ -52,8 +52,10 @@ namespace eval search::circles {
 	    dl_set $g:dist_ys \
 		[dl_unpack [dl_choose $g:dists_pos [dl_llist [dl_llist 1]]]]
 	    
-	    set dist_r [expr $scale*$dist_prop]
-	    set dist_color $targ_color
+            set dist_r [expr $scale*$dist_prop]
+            if { $dist_color == {} } {
+                set dist_color $targ_color
+            }
 	    
 	    dl_set $g:dist_rs [dl_repeat $dist_r [dl_llength $g:dist_xs]]
 	    dl_set $g:dist_colors \

--- a/search/circles/circles_variants.tcl
+++ b/search/circles/circles_variants.tcl
@@ -4,6 +4,7 @@
 #
 # DESCRIPTION
 #   variant dictionary
+#   requires datalib to be loaded before sourcing
 #
 
 namespace eval search::circles {
@@ -11,55 +12,76 @@ namespace eval search::circles {
 	single {
 	    description "no distractors"
 	    loader_proc basic_search
-	    loader_options {
-		nr { 200 100 50 }
-		nd { 0 }
-		targ_r { 1.5 2.0 }
-		dist_prop { 1 }
-		mindist { 1.5 }
-		targ_range { 8 9 10 }
-		targ_color {
-		    { cyan { 0 1 1 } }
-		    { red { 1 0 0 } }
-		}
-	    }
+            loader_options {
+                nr { 200 100 50 }
+                nd { 0 }
+                targ_r { 1.5 2.0 }
+                dist_prop { 1 }
+                mindist { 1.5 }
+                targ_range { 8 9 10 }
+                targ_color {
+                    { cyan { 0 1 1 } }
+                    { red { 1 0 0 } }
+                }
+                dist_color {}
+            }
 	    init { rmtSend "setBackground 10 10 10" } 
 	    deinit {}
 	}
 	variable {
 	    description "variable number of distractors"
 	    loader_proc basic_search
-	    loader_options {
-		nr { 40 60 100 }
-		nd {
-		    { 0,2,4,6,8 { [dl_tcllist [dl_series 0 8 2]] } }
-		    { 0,5,10    { 0 5 10 } }
-		}
-		targ_r { 1.5 2.0 }
-		dist_prop { 1.2 1.1 0.9 0.8 }
-		mindist {1.5 2.0}
-		targ_range { 8 9 10 }
-		targ_color {
-		    { cyan { 0 1 1 } }
-		    { red { 1 0 0 } }
-		}
-	    }
+            loader_options {
+                nr { 40 60 100 }
+                nd {
+                    { 0,2,4,6,8 { [dl_tcllist [dl_series 0 8 2]] } }
+                    { 0,5,10    { 0 5 10 } }
+                }
+                targ_r { 1.5 2.0 }
+                dist_prop { 1.2 1.1 0.9 0.8 }
+                mindist {1.5 2.0}
+                targ_range { 8 9 10 }
+                targ_color {
+                    { cyan { 0 1 1 } }
+                    { red { 1 0 0 } }
+                }
+                dist_color {}
+            }
 	    params { interblock_time 750 }
 	}
-	distractors {
-	    description "fixed number of distractors"
-	    loader_proc basic_search
-	    loader_options {
-		nr { 100 200 }
-		nd { 4 6 8 }
-		targ_r { 1.5 2.0 }
-		dist_prop { 1.2 1.1 0.9 0.8 }
-		mindist { 2.0 3.0 }
-		targ_range { 8 9 10 }
+        distractors {
+            description "fixed number of distractors"
+            loader_proc basic_search
+            loader_options {
+                nr { 100 200 }
+                nd { 4 6 8 }
+                targ_r { 1.5 2.0 }
+                dist_prop { 1.2 1.1 0.9 0.8 }
+                mindist { 2.0 3.0 }
+                targ_range { 8 9 10 }
                 targ_color {
                     { cyan { 0 1 1 } }
                     { red { 1 0 0 } }
                     { purple { 1 0 1 } }
+                }
+                dist_color {}
+            }
+        }
+        diff_color {
+            description "distractors marked by color"
+            loader_proc basic_search
+            loader_options {
+                nr { 100 }
+                nd { 4 }
+                targ_r { 1 }
+                dist_prop { 1 }
+                mindist { 2.0 }
+                targ_range { 8 9 10 }
+                targ_color {
+                    { blue { 0 0 1 } }
+                }
+                dist_color {
+                    { red { 1 0 0 } }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- extend `basic_search` loader with required `dist_color` argument
- default distractor color to the target color when unspecified
- ensure existing variants pass a blank `dist_color`
- keep the new `diff_color` variant using red distractors

## Testing
- `tclsh search/circles/circles_loaders.tcl`
- `tclsh <<'EOF'
proc dl_series args { return {0 2 4 6 8} }
proc dl_tcllist x {return $x}
source search/circles/circles_variants.tcl
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6855b2d661e0832c974e6e613939db12