### PR TITLE
Add diff_color variant for circles search

### DIFF
--- a/search/circles/circles_loaders.tcl
+++ b/search/circles/circles_loaders.tcl
@@ -8,7 +8,7 @@
 
 namespace eval search::circles {
     proc loaders_init { s } {
-        $s add_method basic_search { nr nd targ_r dist_prop mindist targ_range targ_color } {
+        $s add_method basic_search { nr nd targ_r dist_prop mindist targ_range targ_color {dist_color {}} } {
             set n_rep $nr
             set ndists $nd
 
@@ -27,6 +27,7 @@ namespace eval search::circles {
             dl_set $g:targ_y  [dl_mult 2 [dl_sub [dl_urand $n_obs] 0.5] $targ_range]
             dl_set $g:targ_r  [dl_repeat $targ_r $n_obs]
             dl_set $g:targ_color  [dl_repeat [dl_slist $targ_color] $n_obs]
+            if { $dist_color eq "" } { set dist_color $targ_color }
             dl_set $g:targ_pos  [dl_reshape [dl_interleave $g:targ_x $g:targ_y] - 2]
 
             # add distractors
@@ -44,7 +45,6 @@ namespace eval search::circles {
             dl_set $g:dist_ys  [dl_unpack [dl_choose $g:dists_pos [dl_llist [dl_llist 1]]]]
 
             set dist_r [expr $scale*$dist_prop]
-            set dist_color $targ_color
 
             dl_set $g:dist_rs [dl_repeat $dist_r [dl_llength $g:dist_xs]]
             dl_set $g:dist_colors  [dl_repeat [dl_slist $dist_color] [dl_llength $g:dist_xs]]

--- a/search/circles/circles_variants.tcl
+++ b/search/circles/circles_variants.tcl
@@ -17,12 +17,16 @@ namespace eval search::circles {
 		targ_r { 1.5 2.0 }
 		dist_prop { 1 }
 		mindist { 1.5 }
-		targ_range { 8 9 10 }
-		targ_color {
-		    { cyan { 0 1 1 } }
-		    { red { 1 0 0 } }
-		}
-	    }
+                targ_range { 8 9 10 }
+                targ_color {
+                    { cyan { 0 1 1 } }
+                    { red { 1 0 0 } }
+                }
+                dist_color {
+                    { cyan { 0 1 1 } }
+                    { red { 1 0 0 } }
+                }
+            }
 	    init { rmtSend "setBackground 10 10 10" } 
 	    deinit {}
 	}
@@ -38,30 +42,56 @@ namespace eval search::circles {
 		targ_r { 1.5 2.0 }
 		dist_prop { 1.2 1.1 0.9 0.8 }
 		mindist {1.5 2.0}
-		targ_range { 8 9 10 }
-		targ_color {
-		    { cyan { 0 1 1 } }
-		    { red { 1 0 0 } }
-		}
-	    }
-	    params { interblock_time 750 }
-	}
-	distractors {
-	    description "fixed number of distractors"
-	    loader_proc basic_search
-	    loader_options {
-		nr { 100 200 }
-		nd { 4 6 8 }
-		targ_r { 1.5 2.0 }
-		dist_prop { 1.2 1.1 0.9 0.8 }
-		mindist { 2.0 3.0 }
-		targ_range { 8 9 10 }
-		targ_color {
-		    { cyan { 0 1 1 } }
-		    { red { 1 0 0 } }
-		}
-	    }
-	}
+                targ_range { 8 9 10 }
+                targ_color {
+                    { cyan { 0 1 1 } }
+                    { red { 1 0 0 } }
+                }
+                dist_color {
+                    { cyan { 0 1 1 } }
+                    { red { 1 0 0 } }
+                }
+            }
+            params { interblock_time 750 }
+        }
+        distractors {
+            description "fixed number of distractors"
+            loader_proc basic_search
+            loader_options {
+                nr { 100 200 }
+                nd { 4 6 8 }
+                targ_r { 1.5 2.0 }
+                dist_prop { 1.2 1.1 0.9 0.8 }
+                mindist { 2.0 3.0 }
+                targ_range { 8 9 10 }
+                targ_color {
+                    { cyan { 0 1 1 } }
+                    { red { 1 0 0 } }
+                }
+                dist_color {
+                    { cyan { 0 1 1 } }
+                    { red { 1 0 0 } }
+                }
+            }
+        }
+        diff_color {
+            description "distractors identified by color"
+            loader_proc basic_search
+            loader_options {
+                nr { 100 200 }
+                nd { 4 6 8 }
+                targ_r { 1 }
+                dist_prop { 1 }
+                mindist { 1.5 }
+                targ_range { 8 9 10 }
+                targ_color {
+                    { blue { 0 0 1 } }
+                }
+                dist_color {
+                    { red { 1 0 0 } }
+                }
+            }
+        }
     }
     # use subst to replace variables in variant definition above
     set variants [subst $variants]


### PR DESCRIPTION
## Summary
- allow loaders to accept a separate `dist_color` argument
- add new `diff_color` variant that distinguishes target and distractors by colour
- extend existing variants to provide a `dist_color` so old variants continue to load

## Testing
- `tclsh <<'EOF'
source "search/circles/circles_variants.tcl"
puts OK
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685961e3ba3c832c8933fed64a84b6f0