### PR TITLE
Add diff_color variant

### DIFF
--- a/search/circles/circles_loaders.tcl
+++ b/search/circles/circles_loaders.tcl
@@ -8,7 +8,7 @@
 
 namespace eval search::circles {
     proc loaders_init { s } {
-        $s add_method basic_search { nr nd targ_r dist_prop mindist targ_range targ_color } {
+        $s add_method basic_search { nr nd targ_r dist_prop mindist targ_range targ_color {dist_color {}} } {
             set n_rep $nr
             set ndists $nd
 
@@ -44,7 +44,8 @@ namespace eval search::circles {
             dl_set $g:dist_ys  [dl_unpack [dl_choose $g:dists_pos [dl_llist [dl_llist 1]]]]
 
             set dist_r [expr $scale*$dist_prop]
-            set dist_color $targ_color
+
+            if { $dist_color eq {} } { set dist_color $targ_color }
 
             dl_set $g:dist_rs [dl_repeat $dist_r [dl_llength $g:dist_xs]]
             dl_set $g:dist_colors  [dl_repeat [dl_slist $dist_color] [dl_llength $g:dist_xs]]

--- a/search/circles/circles_variants.tcl
+++ b/search/circles/circles_variants.tcl
@@ -11,57 +11,78 @@ namespace eval search::circles {
 	single {
 	    description "no distractors"
 	    loader_proc basic_search
-	    loader_options {
-		nr { 200 100 50 }
-		nd { 0 }
-		targ_r { 1.5 2.0 }
-		dist_prop { 1 }
-		mindist { 1.5 }
-		targ_range { 8 9 10 }
-		targ_color {
-		    { cyan { 0 1 1 } }
-		    { red { 1 0 0 } }
-		}
-	    }
+            loader_options {
+                nr { 200 100 50 }
+                nd { 0 }
+                targ_r { 1.5 2.0 }
+                dist_prop { 1 }
+                mindist { 1.5 }
+                targ_range { 8 9 10 }
+                targ_color {
+                    { cyan { 0 1 1 } }
+                    { red { 1 0 0 } }
+                }
+                dist_color { { same {} } }
+            }
 	    init { rmtSend "setBackground 10 10 10" } 
 	    deinit {}
 	}
 	variable {
 	    description "variable number of distractors"
 	    loader_proc basic_search
-	    loader_options {
-		nr { 40 60 100 }
-		nd {
-		    { 0,2,4,6,8 { [dl_tcllist [dl_series 0 8 2]] } }
-		    { 0,5,10    { 0 5 10 } }
-		}
-		targ_r { 1.5 2.0 }
-		dist_prop { 1.2 1.1 0.9 0.8 }
-		mindist {1.5 2.0}
-		targ_range { 8 9 10 }
-		targ_color {
-		    { cyan { 0 1 1 } }
-		    { red { 1 0 0 } }
-		}
-	    }
+            loader_options {
+                nr { 40 60 100 }
+                nd {
+                    { 0,2,4,6,8 { [dl_tcllist [dl_series 0 8 2]] } }
+                    { 0,5,10    { 0 5 10 } }
+                }
+                targ_r { 1.5 2.0 }
+                dist_prop { 1.2 1.1 0.9 0.8 }
+                mindist {1.5 2.0}
+                targ_range { 8 9 10 }
+                targ_color {
+                    { cyan { 0 1 1 } }
+                    { red { 1 0 0 } }
+                }
+                dist_color { { same {} } }
+            }
 	    params { interblock_time 750 }
 	}
-	distractors {
-	    description "fixed number of distractors"
-	    loader_proc basic_search
-	    loader_options {
-		nr { 100 200 }
-		nd { 4 6 8 }
-		targ_r { 1.5 2.0 }
-		dist_prop { 1.2 1.1 0.9 0.8 }
-		mindist { 2.0 3.0 }
-		targ_range { 8 9 10 }
-		targ_color {
-		    { cyan { 0 1 1 } }
-		    { red { 1 0 0 } }
-		}
-	    }
-	}
+        distractors {
+            description "fixed number of distractors"
+            loader_proc basic_search
+            loader_options {
+                nr { 100 200 }
+                nd { 4 6 8 }
+                targ_r { 1.5 2.0 }
+                dist_prop { 1.2 1.1 0.9 0.8 }
+                mindist { 2.0 3.0 }
+                targ_range { 8 9 10 }
+                targ_color {
+                    { cyan { 0 1 1 } }
+                    { red { 1 0 0 } }
+                }
+                dist_color { { same {} } }
+            }
+        }
+        diff_color {
+            description "target blue, distractors red, same size"
+            loader_proc basic_search
+            loader_options {
+                nr { 100 200 }
+                nd { 4 6 8 }
+                targ_r { 1 }
+                dist_prop { 1 }
+                mindist { 2.0 3.0 }
+                targ_range { 8 9 10 }
+                targ_color {
+                    { blue { 0 0 1 } }
+                }
+                dist_color {
+                    { red { 1 0 0 } }
+                }
+            }
+        }
     }
     # use subst to replace variables in variant definition above
     set variants [subst $variants]


### PR DESCRIPTION
## Summary
- make `basic_search` loader accept `dist_color` option
- ensure all circle search variants provide a `dist_color` entry
- new `diff_color` variant uses red distractors and blue targets

## Testing
- `tclsh` source `search/circles/circles_loaders.tcl`
- `tclsh` source `search/circles/circles_variants.tcl`


------
https://chatgpt.com/codex/tasks/task_e_6859e08dab88832cad2ed979bd78401e